### PR TITLE
Add mobile PWA alarm application

### DIFF
--- a/alarm-app/README.md
+++ b/alarm-app/README.md
@@ -1,0 +1,95 @@
+# Srky Alarm — Mobil PWA Alarm Uygulaması
+
+Her telefonda çalışan (Android, iOS, vb.) basit ve hızlı bir alarm uygulaması.
+Progressive Web App (PWA) olarak hazırlandığı için **uygulama mağazasına gerek yoktur** —
+ana ekrana eklendiğinde gerçek bir uygulama gibi açılır, çevrimdışı da çalışır.
+
+## Özellikler
+
+- Büyük, okunaklı saat (24 saat biçimi)
+- Dilediğin kadar alarm ekleyebilme
+- **Tekrar günleri**: Tek sefer / Hafta içi / Hafta sonu / özel
+- **4 farklı alarm sesi** (Web Audio API ile üretilir — ekstra dosya gerekmez)
+- **Erteleme (snooze)** — 5 dakika
+- **Titreşim** desteği (destekleyen cihazlarda)
+- **Ekranı uyanık tutma** (Wake Lock API)
+- **Sistem bildirimi** (izin verildiğinde)
+- Karanlık / aydınlık tema
+- Alarmlar **cihazda saklanır** (localStorage) — hiçbir veri sunucuya gitmez
+- Tamamen **çevrimdışı** çalışır
+- Açık / aydınlık tema desteği
+- `safe-area` desteği ile çentikli telefonlarda bile düzgün görünür
+
+## Kurulum / Çalıştırma
+
+Uygulama tamamen statik (HTML/CSS/JS) — herhangi bir build adımı gerektirmez.
+
+### Yerel olarak test etmek için
+
+```bash
+cd alarm-app
+# Python 3 ile basit bir HTTP sunucu
+python3 -m http.server 8000
+```
+
+Ardından telefonundan bilgisayarla aynı Wi-Fi ağına bağlanıp tarayıcıda
+`http://<bilgisayarın-ip-adresi>:8000` adresine git.
+
+> **Not:** Service Worker ve Wake Lock API gibi bazı özellikler için
+> `http://localhost` dışında **HTTPS** gerekir. Yayınlamak için GitHub Pages,
+> Netlify, Cloudflare Pages veya Vercel gibi ücretsiz bir servis kullanabilirsin
+> — hepsi otomatik HTTPS sağlar.
+
+### Telefona uygulama olarak yükleme
+
+**Android (Chrome):**
+1. Siteyi Chrome ile aç
+2. Menü (⋮) → **Ana ekrana ekle**
+3. Artık uygulama çekmecesinden başlatılabilir
+
+**iOS (Safari):**
+1. Siteyi Safari ile aç
+2. Paylaş (↑) → **Ana Ekrana Ekle**
+3. İkonu dokunarak aç
+
+## Kullanım
+
+1. **Saat** seç, isteğe bağlı **etiket** yaz (örn. "Okul", "Spor")
+2. Tekrarlamasını istediğin **günleri** seç (hiç seçmezsen bir kez çalar)
+3. **Ses** seç ve **Ekle**'ye bas
+4. Alarmı istediğinde anahtarla **aç/kapat** ya da **Sil**'e basıp kaldır
+5. Alarm çalarken **Durdur** veya **Ertele 5 dk** butonlarını kullan
+
+## Önemli Notlar
+
+- **Tarayıcı arka planda alarm çalar mı?** Uygulama açıkken veya sekme aktif/arka
+  planda tutulduğunda çalar. Telefon tarayıcıları enerji tasarrufu için sekmeleri
+  tamamen askıya alabilir. **En güvenilir kullanım için uygulamayı ana ekrana
+  ekle ve gece ekranı kilitleme ya da uygulamayı aktif tut.**
+- **Ses izni:** İlk açılışta tarayıcı, kullanıcı etkileşimi olmadan ses çalmaya
+  izin vermez. Alt banner'daki **Hazırla** butonuna veya ekrana bir kez
+  dokunduğunda ses sistemi etkinleşir.
+
+## Dosya Yapısı
+
+```
+alarm-app/
+├─ index.html      # Ana sayfa
+├─ styles.css      # Mobil öncelikli, responsive stiller
+├─ app.js          # Alarm mantığı + Web Audio API ile ses üretimi
+├─ sw.js           # Service Worker (çevrimdışı destek)
+├─ manifest.json   # PWA manifest
+├─ icon.svg        # Uygulama ikonu
+└─ README.md
+```
+
+## Teknoloji
+
+- Saf HTML + CSS + Vanilla JavaScript (framework yok)
+- Web Audio API ile dinamik alarm tonları
+- Service Worker ile çevrimdışı çalışma
+- localStorage ile kalıcı veri
+- Wake Lock API ile ekranı uyanık tutma
+- Notification API ile sistem bildirimleri
+
+Herhangi bir bağımlılık, paket yöneticisi ya da build aşaması yoktur.

--- a/alarm-app/app.js
+++ b/alarm-app/app.js
@@ -1,0 +1,495 @@
+/* Srky Alarm - Mobil PWA Alarm Uygulaması */
+(function () {
+  'use strict';
+
+  // -----------------------------
+  // Yardımcılar
+  // -----------------------------
+  const $ = (sel) => document.querySelector(sel);
+  const $$ = (sel) => document.querySelectorAll(sel);
+  const STORAGE_KEY = 'srky.alarms.v1';
+  const THEME_KEY = 'srky.theme';
+  const DAY_NAMES = ['Paz', 'Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt'];
+
+  const pad = (n) => String(n).padStart(2, '0');
+  const uid = () => Math.random().toString(36).slice(2, 10);
+
+  // -----------------------------
+  // Durum
+  // -----------------------------
+  let alarms = loadAlarms();
+  let selectedDays = new Set();
+  let ringing = null; // { alarm, audioStop }
+  let audioCtx = null;
+  let audioUnlocked = false;
+  let snoozeTimeoutId = null;
+
+  function loadAlarms() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      const arr = JSON.parse(raw);
+      return Array.isArray(arr) ? arr : [];
+    } catch (e) {
+      console.warn('Alarmlar yüklenemedi', e);
+      return [];
+    }
+  }
+
+  function saveAlarms() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(alarms));
+  }
+
+  // -----------------------------
+  // Ses üretimi (Web Audio API)
+  // -----------------------------
+  function ensureAudio() {
+    if (!audioCtx) {
+      const Ctx = window.AudioContext || window.webkitAudioContext;
+      if (!Ctx) return null;
+      audioCtx = new Ctx();
+    }
+    return audioCtx;
+  }
+
+  function unlockAudio() {
+    const ctx = ensureAudio();
+    if (!ctx) return;
+    if (ctx.state === 'suspended') ctx.resume();
+    // Çok kısa sessiz bir ton çalarak tarayıcı kilidini aç
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    gain.gain.value = 0.0001;
+    osc.connect(gain).connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.05);
+    audioUnlocked = true;
+    $('#unlockBanner').classList.add('hidden');
+  }
+
+  // Farklı alarm tonları: notaları repeat eden bir döngü
+  function playTone(type) {
+    const ctx = ensureAudio();
+    if (!ctx) return () => {};
+    if (ctx.state === 'suspended') ctx.resume();
+
+    const master = ctx.createGain();
+    master.gain.value = 0.0;
+    master.connect(ctx.destination);
+
+    // Volume envelope
+    const now = ctx.currentTime;
+    master.gain.linearRampToValueAtTime(0.35, now + 0.05);
+
+    const patterns = {
+      beep: { notes: [880, 0, 880, 0, 880, 0, 0, 0], step: 0.18, wave: 'square' },
+      chime: { notes: [523.25, 659.25, 783.99, 1046.5, 0, 0], step: 0.22, wave: 'sine' },
+      digital: { notes: [1200, 0, 1200, 0, 900, 0, 1200, 0], step: 0.12, wave: 'triangle' },
+      wave: { notes: [440, 494, 523, 587, 659, 587, 523, 494], step: 0.2, wave: 'sine' },
+    };
+    const p = patterns[type] || patterns.beep;
+
+    let step = 0;
+    let stopped = false;
+    const nodes = [];
+
+    function schedule() {
+      if (stopped) return;
+      const t = ctx.currentTime;
+      const freq = p.notes[step % p.notes.length];
+      if (freq > 0) {
+        const osc = ctx.createOscillator();
+        const g = ctx.createGain();
+        osc.type = p.wave;
+        osc.frequency.value = freq;
+        g.gain.value = 0;
+        g.gain.linearRampToValueAtTime(0.9, t + 0.01);
+        g.gain.linearRampToValueAtTime(0, t + p.step * 0.9);
+        osc.connect(g).connect(master);
+        osc.start(t);
+        osc.stop(t + p.step);
+        nodes.push(osc);
+      }
+      step++;
+      setTimeout(schedule, p.step * 1000);
+    }
+    schedule();
+
+    return function stop() {
+      stopped = true;
+      try {
+        master.gain.cancelScheduledValues(ctx.currentTime);
+        master.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.05);
+      } catch (e) { /* ignore */ }
+      nodes.forEach((n) => { try { n.stop(); } catch (e) {} });
+    };
+  }
+
+  // Titreşim (destekleyen cihazlarda)
+  function startVibration() {
+    if (!('vibrate' in navigator)) return;
+    const pattern = [400, 200, 400, 200, 600, 400];
+    navigator.vibrate(pattern);
+    // Periyodik titreşim
+    ringing && (ringing.vibrateId = setInterval(() => navigator.vibrate(pattern), 2200));
+  }
+  function stopVibration() {
+    if ('vibrate' in navigator) navigator.vibrate(0);
+    if (ringing && ringing.vibrateId) clearInterval(ringing.vibrateId);
+  }
+
+  // -----------------------------
+  // Saat
+  // -----------------------------
+  function updateClock() {
+    const now = new Date();
+    $('#currentTime').textContent = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
+    const opts = { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' };
+    try {
+      $('#currentDate').textContent = now.toLocaleDateString('tr-TR', opts);
+    } catch (e) {
+      $('#currentDate').textContent = now.toDateString();
+    }
+  }
+
+  // -----------------------------
+  // Alarm oluşturma
+  // -----------------------------
+  function addAlarm() {
+    const time = $('#alarmTime').value;
+    if (!time) return;
+    const [h, m] = time.split(':').map(Number);
+    const label = $('#alarmLabel').value.trim();
+    const sound = $('#alarmSound').value;
+    const days = Array.from(selectedDays).sort();
+
+    const alarm = {
+      id: uid(),
+      hour: h,
+      minute: m,
+      label,
+      sound,
+      days, // boş => tek seferlik
+      enabled: true,
+      // Tek seferlik alarmlar için hedef timestamp (bir sonraki oluşum) hesaplanır
+    };
+    alarms.push(alarm);
+    saveAlarms();
+    renderAlarms();
+
+    // Formu sıfırla
+    $('#alarmLabel').value = '';
+    selectedDays.clear();
+    $$('.day').forEach((d) => d.classList.remove('active'));
+
+    // Sesi etkinleştirmeye çalış (kullanıcı etkileşimi var)
+    if (!audioUnlocked) unlockAudio();
+  }
+
+  function removeAlarm(id) {
+    alarms = alarms.filter((a) => a.id !== id);
+    saveAlarms();
+    renderAlarms();
+  }
+
+  function toggleAlarm(id, enabled) {
+    const a = alarms.find((x) => x.id === id);
+    if (!a) return;
+    a.enabled = enabled;
+    // Eğer etkinleştiriliyorsa ertelemeyi de temizle
+    delete a.snoozedUntil;
+    saveAlarms();
+    renderAlarms();
+  }
+
+  // -----------------------------
+  // Tetikleme
+  // -----------------------------
+  let lastCheckKey = '';
+  function checkAlarms() {
+    if (ringing) return;
+    const now = new Date();
+    // Her dakikada bir tetikle (aynı dakika içinde tekrar tetiklenmesin)
+    const key = `${now.getFullYear()}-${now.getMonth()}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}`;
+    if (key === lastCheckKey) return;
+
+    const hr = now.getHours();
+    const mn = now.getMinutes();
+    const dow = now.getDay();
+    const ts = now.getTime();
+
+    for (const a of alarms) {
+      if (!a.enabled) continue;
+
+      // Erteleme kontrolü
+      if (a.snoozedUntil && ts >= a.snoozedUntil && ts < a.snoozedUntil + 60000) {
+        delete a.snoozedUntil;
+        saveAlarms();
+        triggerAlarm(a);
+        lastCheckKey = key;
+        return;
+      }
+      if (a.snoozedUntil && ts < a.snoozedUntil) continue;
+
+      if (a.hour === hr && a.minute === mn) {
+        const repeats = a.days && a.days.length > 0;
+        if (repeats) {
+          if (a.days.includes(dow)) {
+            triggerAlarm(a);
+            lastCheckKey = key;
+            return;
+          }
+        } else {
+          // Tek seferlik: tetikle ve devre dışı bırak
+          triggerAlarm(a);
+          a.enabled = false;
+          saveAlarms();
+          renderAlarms();
+          lastCheckKey = key;
+          return;
+        }
+      }
+    }
+    lastCheckKey = key;
+  }
+
+  function triggerAlarm(alarm) {
+    const stopAudio = playTone(alarm.sound || 'beep');
+    ringing = { alarm, stopAudio };
+    startVibration();
+
+    // Modalı aç
+    $('#ringLabel').textContent = alarm.label
+      ? alarm.label
+      : `${pad(alarm.hour)}:${pad(alarm.minute)}`;
+    $('#ringOverlay').classList.remove('hidden');
+
+    // Ekranı uyanık tutmaya çalış
+    requestWakeLock();
+
+    // Sistem bildirimi (izin varsa)
+    try {
+      if ('Notification' in window && Notification.permission === 'granted') {
+        new Notification('⏰ Alarm', {
+          body: alarm.label || `${pad(alarm.hour)}:${pad(alarm.minute)}`,
+          icon: 'icon.svg',
+          tag: 'srky-alarm',
+          renotify: true,
+        });
+      }
+    } catch (e) { /* ignore */ }
+  }
+
+  function stopRinging() {
+    if (!ringing) return;
+    try { ringing.stopAudio && ringing.stopAudio(); } catch (e) {}
+    stopVibration();
+    ringing = null;
+    $('#ringOverlay').classList.add('hidden');
+    releaseWakeLock();
+  }
+
+  function snoozeRinging() {
+    if (!ringing) return;
+    const a = ringing.alarm;
+    // 5 dk sonraya ertele
+    const target = Date.now() + 5 * 60 * 1000;
+    const stored = alarms.find((x) => x.id === a.id);
+    if (stored) {
+      stored.snoozedUntil = target;
+      stored.enabled = true;
+      saveAlarms();
+    }
+    stopRinging();
+    renderAlarms();
+  }
+
+  // -----------------------------
+  // Wake Lock (destekleyen cihazlarda)
+  // -----------------------------
+  let wakeLock = null;
+  async function requestWakeLock() {
+    try {
+      if ('wakeLock' in navigator) {
+        wakeLock = await navigator.wakeLock.request('screen');
+      }
+    } catch (e) { /* ignore */ }
+  }
+  function releaseWakeLock() {
+    try { wakeLock && wakeLock.release(); } catch (e) {}
+    wakeLock = null;
+  }
+
+  // -----------------------------
+  // Render
+  // -----------------------------
+  function formatDays(days) {
+    if (!days || days.length === 0) return 'Bir kez';
+    if (days.length === 7) return 'Her gün';
+    // Hafta içi / hafta sonu kısaltmaları
+    const wd = [1, 2, 3, 4, 5];
+    const we = [0, 6];
+    const sorted = [...days].sort();
+    if (JSON.stringify(sorted) === JSON.stringify(wd)) return 'Hafta içi';
+    if (JSON.stringify(sorted) === JSON.stringify(we)) return 'Hafta sonu';
+    return sorted.map((d) => DAY_NAMES[d]).join(' · ');
+  }
+
+  function renderAlarms() {
+    const list = $('#alarmList');
+    list.innerHTML = '';
+    // Saate göre sırala
+    const sorted = [...alarms].sort((a, b) => (a.hour * 60 + a.minute) - (b.hour * 60 + b.minute));
+
+    for (const a of sorted) {
+      const li = document.createElement('li');
+      li.className = 'alarm-item' + (a.enabled ? '' : ' disabled');
+
+      const main = document.createElement('div');
+      main.className = 'alarm-main';
+
+      const time = document.createElement('div');
+      time.className = 'alarm-time';
+      time.textContent = `${pad(a.hour)}:${pad(a.minute)}`;
+
+      const label = document.createElement('div');
+      label.className = 'alarm-label';
+      label.textContent = a.label || 'Alarm';
+
+      const days = document.createElement('div');
+      days.className = 'alarm-days';
+      let daysText = formatDays(a.days);
+      if (a.snoozedUntil && a.snoozedUntil > Date.now()) {
+        const dt = new Date(a.snoozedUntil);
+        daysText += ` · Ertelendi → ${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
+      }
+      days.textContent = daysText;
+
+      main.appendChild(time);
+      main.appendChild(label);
+      main.appendChild(days);
+
+      const ctrl = document.createElement('div');
+      ctrl.className = 'alarm-ctrl';
+
+      const sw = document.createElement('label');
+      sw.className = 'switch';
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.checked = !!a.enabled;
+      input.addEventListener('change', () => toggleAlarm(a.id, input.checked));
+      const slider = document.createElement('span');
+      slider.className = 'slider';
+      sw.appendChild(input);
+      sw.appendChild(slider);
+
+      const del = document.createElement('button');
+      del.className = 'del-btn';
+      del.textContent = 'Sil';
+      del.addEventListener('click', () => {
+        if (confirm('Alarmı silmek istediğinize emin misiniz?')) removeAlarm(a.id);
+      });
+
+      ctrl.appendChild(sw);
+      ctrl.appendChild(del);
+
+      li.appendChild(main);
+      li.appendChild(ctrl);
+      list.appendChild(li);
+    }
+
+    $('#alarmCount').textContent = alarms.length;
+    $('#emptyState').style.display = alarms.length ? 'none' : 'block';
+  }
+
+  // -----------------------------
+  // Tema
+  // -----------------------------
+  function applyTheme(theme) {
+    if (theme === 'light') document.documentElement.classList.add('light');
+    else document.documentElement.classList.remove('light');
+    localStorage.setItem(THEME_KEY, theme);
+  }
+  function toggleTheme() {
+    const cur = localStorage.getItem(THEME_KEY) || 'dark';
+    applyTheme(cur === 'dark' ? 'light' : 'dark');
+  }
+
+  // -----------------------------
+  // Olaylar
+  // -----------------------------
+  function bindEvents() {
+    $('#addAlarmBtn').addEventListener('click', addAlarm);
+    $('#stopBtn').addEventListener('click', stopRinging);
+    $('#snoozeBtn').addEventListener('click', snoozeRinging);
+    $('#themeBtn').addEventListener('click', toggleTheme);
+    $('#unlockBtn').addEventListener('click', () => {
+      unlockAudio();
+      requestNotificationPermission();
+    });
+
+    $$('.day').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const d = Number(btn.dataset.day);
+        if (selectedDays.has(d)) {
+          selectedDays.delete(d);
+          btn.classList.remove('active');
+        } else {
+          selectedDays.add(d);
+          btn.classList.add('active');
+        }
+      });
+    });
+
+    // Sekmeye geri dönünce saati/alarmı tazele
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) {
+        updateClock();
+        checkAlarms();
+      }
+    });
+
+    // Ses için ilk kullanıcı etkileşiminde kilidi kaldır
+    const unlockOnce = () => {
+      if (!audioUnlocked) unlockAudio();
+      document.removeEventListener('touchstart', unlockOnce);
+      document.removeEventListener('click', unlockOnce);
+    };
+    document.addEventListener('touchstart', unlockOnce, { passive: true });
+    document.addEventListener('click', unlockOnce);
+  }
+
+  function requestNotificationPermission() {
+    if ('Notification' in window && Notification.permission === 'default') {
+      try { Notification.requestPermission(); } catch (e) {}
+    }
+  }
+
+  // -----------------------------
+  // Başlat
+  // -----------------------------
+  function init() {
+    applyTheme(localStorage.getItem(THEME_KEY) || 'dark');
+    bindEvents();
+    renderAlarms();
+    updateClock();
+    setInterval(() => {
+      updateClock();
+      checkAlarms();
+    }, 1000);
+
+    // Ses izni banner'ı göster (sadece bir kez)
+    if (!audioUnlocked) {
+      setTimeout(() => {
+        if (!audioUnlocked) $('#unlockBanner').classList.remove('hidden');
+      }, 500);
+    }
+
+    // Service worker
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('sw.js').catch(() => {});
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/alarm-app/icon.svg
+++ b/alarm-app/icon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1e3a8a"/>
+      <stop offset="1" stop-color="#0b1020"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#60a5fa"/>
+      <stop offset="1" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#bg)"/>
+  <circle cx="256" cy="272" r="150" fill="none" stroke="url(#ring)" stroke-width="24"/>
+  <circle cx="256" cy="272" r="150" fill="#0b1020"/>
+  <line x1="256" y1="272" x2="256" y2="170" stroke="#f8fafc" stroke-width="14" stroke-linecap="round"/>
+  <line x1="256" y1="272" x2="326" y2="272" stroke="#60a5fa" stroke-width="12" stroke-linecap="round"/>
+  <circle cx="256" cy="272" r="10" fill="#f8fafc"/>
+  <path d="M110 150 L170 90" stroke="url(#ring)" stroke-width="28" stroke-linecap="round"/>
+  <path d="M402 150 L342 90" stroke="url(#ring)" stroke-width="28" stroke-linecap="round"/>
+</svg>

--- a/alarm-app/index.html
+++ b/alarm-app/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />
+  <meta name="theme-color" content="#0b1020" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Alarm" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="description" content="Basit, hızlı ve çevrimdışı çalışan mobil alarm uygulaması" />
+  <link rel="manifest" href="manifest.json" />
+  <link rel="icon" type="image/svg+xml" href="icon.svg" />
+  <link rel="apple-touch-icon" href="icon.svg" />
+  <link rel="stylesheet" href="styles.css" />
+  <title>Srky Alarm</title>
+</head>
+<body>
+  <main class="app">
+    <header class="header">
+      <div class="brand">
+        <span class="brand-dot"></span>
+        <h1>Alarm</h1>
+      </div>
+      <button id="themeBtn" class="icon-btn" aria-label="Tema değiştir" title="Tema">
+        <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z"/></svg>
+      </button>
+    </header>
+
+    <section class="clock" aria-live="polite">
+      <div id="currentTime" class="clock-time">--:--</div>
+      <div id="currentDate" class="clock-date">--</div>
+    </section>
+
+    <section class="add-card">
+      <h2>Yeni Alarm</h2>
+      <div class="add-row">
+        <input id="alarmTime" type="time" value="07:00" aria-label="Alarm saati" />
+        <input id="alarmLabel" type="text" placeholder="Etiket (ör. Okul)" maxlength="30" aria-label="Alarm etiketi" />
+      </div>
+      <div class="days" role="group" aria-label="Tekrar günleri">
+        <button type="button" class="day" data-day="1">Pzt</button>
+        <button type="button" class="day" data-day="2">Sal</button>
+        <button type="button" class="day" data-day="3">Çar</button>
+        <button type="button" class="day" data-day="4">Per</button>
+        <button type="button" class="day" data-day="5">Cum</button>
+        <button type="button" class="day" data-day="6">Cmt</button>
+        <button type="button" class="day" data-day="0">Paz</button>
+      </div>
+      <div class="add-actions">
+        <label class="sound-label">
+          <span>Ses</span>
+          <select id="alarmSound" aria-label="Alarm sesi">
+            <option value="beep">Klasik Bip</option>
+            <option value="chime">Çan</option>
+            <option value="digital">Dijital</option>
+            <option value="wave">Dalga</option>
+          </select>
+        </label>
+        <button id="addAlarmBtn" class="primary">Ekle</button>
+      </div>
+    </section>
+
+    <section class="list-card">
+      <div class="list-head">
+        <h2>Alarmlarım</h2>
+        <span id="alarmCount" class="count">0</span>
+      </div>
+      <ul id="alarmList" class="alarm-list" aria-live="polite"></ul>
+      <p id="emptyState" class="empty">Henüz alarm yok. Yukarıdan bir alarm ekle.</p>
+    </section>
+
+    <footer class="footer">
+      <p>Ana ekrana ekleyerek uygulama gibi kullanabilirsin.</p>
+    </footer>
+  </main>
+
+  <!-- Alarm ringing modal -->
+  <div id="ringOverlay" class="overlay hidden" role="alertdialog" aria-modal="true" aria-labelledby="ringTitle">
+    <div class="ring-card">
+      <div class="ring-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" width="64" height="64" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M6 8a6 6 0 1 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
+          <path d="M10 21a2 2 0 0 0 4 0"/>
+        </svg>
+      </div>
+      <div id="ringTitle" class="ring-title">Alarm!</div>
+      <div id="ringLabel" class="ring-label">—</div>
+      <div class="ring-actions">
+        <button id="snoozeBtn" class="secondary">Ertele 5 dk</button>
+        <button id="stopBtn" class="primary">Durdur</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Permission / unlock prompt -->
+  <div id="unlockBanner" class="banner hidden">
+    <span>Alarmın çalabilmesi için bir kez sayfaya dokun.</span>
+    <button id="unlockBtn" class="primary small">Hazırla</button>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/alarm-app/manifest.json
+++ b/alarm-app/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Srky Alarm",
+  "short_name": "Alarm",
+  "description": "Basit, hızlı ve çevrimdışı çalışan mobil alarm uygulaması",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0b1020",
+  "theme_color": "#0b1020",
+  "lang": "tr",
+  "dir": "ltr",
+  "scope": "./",
+  "icons": [
+    {
+      "src": "icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/alarm-app/styles.css
+++ b/alarm-app/styles.css
@@ -1,0 +1,437 @@
+:root {
+  --bg-0: #0b1020;
+  --bg-1: #111a33;
+  --bg-2: #1a2547;
+  --fg: #f8fafc;
+  --fg-dim: #b5c0d8;
+  --fg-muted: #7b88a8;
+  --accent: #60a5fa;
+  --accent-2: #a78bfa;
+  --danger: #f87171;
+  --ok: #34d399;
+  --border: rgba(255, 255, 255, 0.08);
+  --card: rgba(255, 255, 255, 0.04);
+  --shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+  --radius: 18px;
+  --radius-sm: 12px;
+}
+
+:root.light {
+  --bg-0: #f3f5fb;
+  --bg-1: #ffffff;
+  --bg-2: #eef1fa;
+  --fg: #0b1020;
+  --fg-dim: #3a445e;
+  --fg-muted: #6b7690;
+  --border: rgba(11, 16, 32, 0.08);
+  --card: rgba(11, 16, 32, 0.03);
+  --shadow: 0 10px 40px rgba(11, 16, 32, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: radial-gradient(ellipse at top, var(--bg-1), var(--bg-0) 60%);
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.45;
+  overscroll-behavior-y: none;
+}
+
+body {
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+.app {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 18px 16px 100px;
+}
+
+/* Header */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.brand-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  box-shadow: 0 0 14px var(--accent);
+}
+.brand h1 {
+  font-size: 20px;
+  margin: 0;
+  letter-spacing: 0.4px;
+}
+.icon-btn {
+  background: var(--card);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+.icon-btn:active { transform: scale(0.94); }
+
+/* Clock */
+.clock {
+  text-align: center;
+  padding: 28px 12px 22px;
+  margin-bottom: 18px;
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, rgba(96, 165, 250, 0.12), rgba(167, 139, 250, 0.04));
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+.clock-time {
+  font-size: clamp(54px, 16vw, 84px);
+  font-weight: 700;
+  letter-spacing: 1px;
+  font-variant-numeric: tabular-nums;
+  background: linear-gradient(90deg, var(--fg), var(--accent));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.clock-date {
+  color: var(--fg-dim);
+  font-size: 14px;
+  margin-top: 4px;
+  text-transform: capitalize;
+}
+
+/* Cards */
+.add-card, .list-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  margin-bottom: 16px;
+}
+.add-card h2, .list-head h2 {
+  margin: 0 0 12px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg-dim);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+/* Inputs */
+.add-row {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+input[type="time"], input[type="text"], select {
+  width: 100%;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  font-size: 16px;
+  outline: none;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+input[type="time"] {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+input:focus, select:focus {
+  border-color: var(--accent);
+}
+
+/* Days */
+.days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+  margin-bottom: 12px;
+}
+.day {
+  background: var(--bg-2);
+  color: var(--fg-dim);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 0;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.day.active {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 4px 14px rgba(96, 165, 250, 0.3);
+}
+.day:active { transform: scale(0.95); }
+
+/* Actions row */
+.add-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.sound-label {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+.sound-label select { flex: 1; }
+
+.primary, .secondary {
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 12px 18px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, opacity 0.2s ease;
+}
+.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #fff;
+  box-shadow: 0 6px 18px rgba(96, 165, 250, 0.25);
+}
+.secondary {
+  background: var(--bg-2);
+  color: var(--fg);
+  border: 1px solid var(--border);
+}
+.primary:active, .secondary:active { transform: scale(0.96); }
+.primary.small { padding: 8px 14px; font-size: 13px; }
+
+/* Alarm list */
+.list-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.count {
+  background: var(--bg-2);
+  color: var(--fg-dim);
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.alarm-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.alarm-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 14px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  margin-bottom: 10px;
+  transition: opacity 0.2s ease;
+}
+.alarm-item.disabled { opacity: 0.5; }
+.alarm-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.alarm-time {
+  font-size: 30px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.5px;
+}
+.alarm-label {
+  font-size: 13px;
+  color: var(--fg-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.alarm-days {
+  font-size: 11px;
+  color: var(--fg-muted);
+  margin-top: 2px;
+  letter-spacing: 0.5px;
+}
+.alarm-ctrl {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+.del-btn {
+  background: transparent;
+  border: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.del-btn:hover { color: var(--danger); }
+
+/* Toggle switch */
+.switch {
+  position: relative;
+  width: 46px;
+  height: 26px;
+  display: inline-block;
+}
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.slider {
+  position: absolute;
+  inset: 0;
+  background: #374151;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+  cursor: pointer;
+}
+.slider::before {
+  content: "";
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  left: 3px;
+  top: 3px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s ease;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+}
+.switch input:checked + .slider {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+}
+.switch input:checked + .slider::before {
+  transform: translateX(20px);
+}
+
+.empty {
+  text-align: center;
+  color: var(--fg-muted);
+  font-size: 13px;
+  padding: 14px 0 4px;
+  margin: 0;
+}
+
+.footer {
+  text-align: center;
+  color: var(--fg-muted);
+  font-size: 12px;
+  margin-top: 20px;
+}
+
+/* Ring overlay */
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 16, 32, 0.85);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  display: grid;
+  place-items: center;
+  z-index: 100;
+  animation: fade 0.2s ease;
+}
+.overlay.hidden { display: none; }
+@keyframes fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.ring-card {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 36px 24px 24px;
+  max-width: 320px;
+  width: calc(100% - 40px);
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+.ring-icon {
+  color: var(--accent);
+  animation: shake 0.6s infinite;
+}
+@keyframes shake {
+  0%, 100% { transform: rotate(0); }
+  25% { transform: rotate(-10deg); }
+  75% { transform: rotate(10deg); }
+}
+.ring-title {
+  font-size: 24px;
+  font-weight: 700;
+  margin-top: 8px;
+}
+.ring-label {
+  color: var(--fg-dim);
+  margin: 4px 0 22px;
+  font-size: 14px;
+}
+.ring-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+/* Unlock banner */
+.banner {
+  position: fixed;
+  left: 12px;
+  right: 12px;
+  bottom: calc(12px + env(safe-area-inset-bottom));
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  box-shadow: var(--shadow);
+  font-size: 13px;
+  color: var(--fg-dim);
+  max-width: 540px;
+  margin: 0 auto;
+  z-index: 50;
+}
+.banner.hidden { display: none; }
+
+@media (max-width: 360px) {
+  .add-row { grid-template-columns: 1fr; }
+  .day { padding: 9px 0; font-size: 11px; }
+  .alarm-time { font-size: 26px; }
+}

--- a/alarm-app/sw.js
+++ b/alarm-app/sw.js
@@ -1,0 +1,45 @@
+/* Srky Alarm Service Worker */
+const CACHE = 'srky-alarm-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  './manifest.json',
+  './icon.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE).then((cache) => cache.addAll(ASSETS)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)))
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  if (req.method !== 'GET') return;
+  event.respondWith(
+    caches.match(req).then((cached) => {
+      if (cached) return cached;
+      return fetch(req).then((res) => {
+        // Aynı kaynaksa cache'e al
+        try {
+          const url = new URL(req.url);
+          if (url.origin === self.location.origin) {
+            const copy = res.clone();
+            caches.open(CACHE).then((cache) => cache.put(req, copy));
+          }
+        } catch (e) { /* ignore */ }
+        return res;
+      }).catch(() => cached);
+    })
+  );
+});


### PR DESCRIPTION
Cross-platform web-based alarm clock that installs to any phone's home
screen without an app store. Includes repeat days, snooze, vibration,
wake lock, 4 synthesized alarm tones, dark/light theme, and full
offline support via service worker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new client-side alarm implementation relying on browser/device APIs (Web Audio, Wake Lock, Notifications, service worker caching), which can behave inconsistently across platforms and requires careful manual testing on mobile.
> 
> **Overview**
> Introduces a new `alarm-app/` static Progressive Web App that runs fully offline and can be installed to a phone home screen via `manifest.json` + `sw.js` asset caching.
> 
> Implements alarm creation/management in `app.js` (repeat-day scheduling, one-time alarms, snooze, enable/disable, localStorage persistence) plus synthesized tones via Web Audio, optional vibration, wake-lock while ringing, and notification prompts.
> 
> Adds the full mobile UI (`index.html` + `styles.css`), theme toggle (dark/light), an in-app ringing modal, and an SVG app icon, with a README documenting setup and platform caveats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0dab3319580c55fa843d0fa6a0794b9fbd8ec7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->